### PR TITLE
attestation: implement apple format

### DIFF
--- a/attestation_statement.go
+++ b/attestation_statement.go
@@ -104,6 +104,8 @@ func VerifyAttestationStatement(
 	clientDataJSONHash ClientDataJSONHash,
 ) error {
 	switch attestationObject.Format {
+	case AttestationFormatApple:
+		return VerifyAppleAttestationStatement(attestationObject, clientDataJSONHash)
 	case AttestationFormatPacked:
 		return VerifyPackedAttestationStatement(attestationObject, clientDataJSONHash)
 	default:

--- a/attestation_statement_apple.go
+++ b/attestation_statement_apple.go
@@ -1,0 +1,76 @@
+package webauthn
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"crypto/subtle"
+	"fmt"
+
+	"github.com/pomerium/webauthn/cose"
+)
+
+// VerifyAppleAttestationStatement verifies that an AttestationObject's attestation statement is valid according to the
+// packed verification procedure.
+func VerifyAppleAttestationStatement(
+	attestationObject *AttestationObject,
+	clientDataJSONHash ClientDataJSONHash,
+) error {
+	certificate, err := attestationObject.Statement.UnmarshalCertificate()
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+
+	authenticatorData, err := attestationObject.UnmarshalAuthenticatorData()
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+
+	publicKey, _, err := cose.UnmarshalPublicKey(
+		authenticatorData.AttestedCredentialData.CredentialPublicKey,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+
+	// 2. Concatenate authenticatorData and clientDataHash to form nonceToHash.
+	nonceToHash := concat(attestationObject.AuthData, clientDataJSONHash[:])
+
+	// 3. Perform SHA-256 hash of nonceToHash to produce nonce.
+	nonce := sha256.Sum256(nonceToHash)
+
+	// 4. Verify that nonce equals the value of the extension with OID 1.2.840.113635.100.8.2 in credCert.
+	certificateNonce, err := getCertificateAppleNonce(certificate)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+	if subtle.ConstantTimeCompare(nonce[:], certificateNonce) != 1 {
+		return fmt.Errorf("%w: invalid nonce", ErrInvalidAttestationStatement)
+	}
+
+	// 5. Verify that the credential public key equals the Subject Public Key of credCert.
+	err = verifyAppleAttestationStatementCredentialPublicKey(
+		certificate.PublicKey,
+		publicKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyAppleAttestationStatementCredentialPublicKey(
+	certificatePublicKey, credentialPublicKey crypto.PublicKey,
+) error {
+	withEqual, ok := certificatePublicKey.(interface {
+		Equal(x crypto.PublicKey) bool
+	})
+	if !ok {
+		return fmt.Errorf("%w: unsupported key type: %T", ErrInvalidAttestationStatement, certificatePublicKey)
+	}
+
+	if withEqual.Equal(credentialPublicKey) {
+		return fmt.Errorf("%w: mismatched public keys", ErrInvalidAttestationStatement)
+	}
+	return nil
+}

--- a/attestation_statement_apple_test.go
+++ b/attestation_statement_apple_test.go
@@ -1,0 +1,23 @@
+package webauthn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAppleAttestationStatement(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, name := range []string{"Apple"} {
+			response := readTestAuthenticatorAttestationResponse(t, name)
+			attestationObject, err := response.UnmarshalAttestationObject()
+			require.NoError(t, err)
+			clientDataJSONHash := response.GetClientDataJSONHash()
+			t.Run(name, func(t *testing.T) {
+				err = VerifyAttestationStatement(attestationObject, clientDataJSONHash)
+				assert.NoError(t, err)
+			})
+		}
+	})
+}

--- a/certificate.go
+++ b/certificate.go
@@ -7,12 +7,15 @@ import (
 )
 
 var (
+	errInvalidAppleNonce    = errors.New("invalid apple nonce")
 	errMissingAAGUID        = errors.New("missing AAGUID")
+	errMissingAppleNonce    = errors.New("missing apple nonce")
 	errAAGUIDMarkedCritical = errors.New("AAGUID marked critical")
 )
 
 var (
-	oidAAGUID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 45724, 1, 1, 4}
+	oidAAGUID     = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 45724, 1, 1, 4}
+	oidAppleNonce = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 2}
 )
 
 func getCertificateAAGUID(certificate *x509.Certificate) (AAGUID, error) {
@@ -30,4 +33,24 @@ func getCertificateAAGUID(certificate *x509.Certificate) (AAGUID, error) {
 		}
 	}
 	return AAGUID{}, errMissingAAGUID
+}
+
+func getCertificateAppleNonce(certificate *x509.Certificate) ([]byte, error) {
+	type appleAnonymousAttestation struct {
+		Nonce []byte `asn1:"tag:1,explicit"`
+	}
+
+	for _, extension := range certificate.Extensions {
+		if !extension.Id.Equal(oidAppleNonce) {
+			continue
+		}
+
+		var value appleAnonymousAttestation
+		_, err := asn1.Unmarshal(extension.Value, &value)
+		if err != nil {
+			return nil, errInvalidAppleNonce
+		}
+		return value.Nonce, nil
+	}
+	return nil, errMissingAppleNonce
 }


### PR DESCRIPTION
Add verification of the apple anonymous attestation format as defined here: https://www.w3.org/TR/webauthn-2/#sctn-apple-anonymous-attestation. 

Verification of the attestation statement is pretty simple, but a complete solution will also need to verify the trust chain of certificates. A subsequent PR will add some helpers to make this easier to do. Apple's root cert is here: https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem.

Fixes https://github.com/pomerium/internal/issues/591