### PR TITLE
attestation: fido-u2f support

### DIFF
--- a/attestation_statement.go
+++ b/attestation_statement.go
@@ -110,6 +110,8 @@ func VerifyAttestationStatement(
 		return VerifyAndroidSafetyNetAttestationStatement(attestationObject, clientDataJSONHash)
 	case AttestationFormatApple:
 		return VerifyAppleAttestationStatement(attestationObject, clientDataJSONHash)
+	case AttestationFormatFIDOU2F:
+		return VerifyFIDOU2FAttestationStatement(attestationObject, clientDataJSONHash)
 	case AttestationFormatPacked:
 		return VerifyPackedAttestationStatement(attestationObject, clientDataJSONHash)
 	default:

--- a/attestation_statement_fido_u2f.go
+++ b/attestation_statement_fido_u2f.go
@@ -1,0 +1,90 @@
+package webauthn
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"fmt"
+
+	"github.com/pomerium/webauthn/cose"
+)
+
+// VerifyFIDOU2FAttestationStatement verifies a fido-u2f formatted attestation statement according to procedure
+// documented here: https://www.w3.org/TR/webauthn-2/#sctn-fido-u2f-attestation.
+func VerifyFIDOU2FAttestationStatement(
+	attestationObject *AttestationObject,
+	clientDataJSONHash ClientDataJSONHash,
+) error {
+	// 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to
+	//    extract the contained fields.
+	//    - by this point the attestation statement has already been CBOR decoded
+
+	// 2. Check that x5c has exactly one element and let attCert be that element. Let certificate public key be the
+	//    public key conveyed by attCert. If certificate public key is not an Elliptic Curve (EC) public key over the
+	//    P-256 curve, terminate this algorithm and return an appropriate error.
+	certificate, err := attestationObject.Statement.UnmarshalCertificate()
+	if err != nil {
+		return fmt.Errorf("%w: invalid x5c certificate: %s", ErrInvalidAttestationStatement, err)
+	}
+	publicKey, ok := certificate.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("%w: invalid x5c certificate, only ECDSA keys are supported", ErrInvalidAttestationStatement)
+	}
+	if publicKey.Curve != elliptic.P256() {
+		return fmt.Errorf("%w: invalid x5c certificate, only the P-256 curve is supported",
+			ErrInvalidAttestationStatement)
+	}
+
+	// 3. Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from
+	//    authenticatorData.attestedCredentialData.
+	authenticatorData, err := attestationObject.UnmarshalAuthenticatorData()
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+	rpIDHash := authenticatorData.RPIDHash
+	credentialID := authenticatorData.AttestedCredentialData.CredentialID
+
+	// 4. Convert the COSE_KEY formatted credentialPublicKey (see Section 7 of [RFC8152]) to Raw ANSI X9.62 public key
+	//    format (see ALG_KEY_ECC_X962_RAW in Section 3.6.2 Public Key Representation Formats of [FIDO-Registry]).
+	credentialPublicKey, _, err := cose.UnmarshalPublicKey(authenticatorData.AttestedCredentialData.CredentialPublicKey)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidAttestationStatement, err)
+	}
+
+	//    4a. Let x be the value corresponding to the "-2" key (representing x coordinate) in credentialPublicKey, and
+	//        confirm its size to be of 32 bytes. If size differs or "-2" key is not found, terminate this algorithm and
+	//        return an appropriate error.
+
+	//    4b. Let y be the value corresponding to the "-3" key (representing y coordinate) in credentialPublicKey, and
+	//        confirm its size to be of 32 bytes. If size differs or "-3" key is not found, terminate this algorithm and
+	//        return an appropriate error.
+	ecdsaKey, ok := credentialPublicKey.(*cose.ECDSAPublicKey)
+	if !ok {
+		return fmt.Errorf("%w: only ECDSA keys are supported", ErrInvalidAttestationStatement)
+	}
+	//    4c. Let publicKeyU2F be the concatenation 0x04 || x || y.
+	publicKeyU2F := ecdsaKey.RawX962ECC()
+
+	// 5. Let verificationData be the concatenation of (0x00 || rpIdHash || clientDataHash || credentialId ||
+	//    publicKeyU2F) (see Section 4.3 of [FIDO-U2F-Message-Formats]).
+	verificationData := concat(
+		[]byte{0x00},
+		rpIDHash[:],
+		clientDataJSONHash[:],
+		credentialID,
+		publicKeyU2F[:],
+	)
+
+	// 6. Verify the sig using verificationData and the certificate public key per section 4.1.4 of [SEC1] with SHA-256
+	//    as the hash function used in step two.
+	signature := attestationObject.Statement.GetSignature()
+	err = certificate.CheckSignature(
+		credentialPublicKey.Algorithm().X509SignatureAlgorithm(),
+		verificationData,
+		signature,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: invalid signature, %s", ErrInvalidAttestationStatement, err)
+	}
+
+	return nil
+}

--- a/attestation_statement_fido_u2f_test.go
+++ b/attestation_statement_fido_u2f_test.go
@@ -1,0 +1,149 @@
+package webauthn
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"math/big"
+	"testing"
+
+	"github.com/pomerium/webauthn/cose"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyFIDOU2FAttestationStatement(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, name := range []string{"U2F"} {
+			response := readTestAuthenticatorAttestationResponse(t, name)
+			attestationObject, err := response.UnmarshalAttestationObject()
+			require.NoError(t, err)
+			clientDataJSONHash := response.GetClientDataJSONHash()
+			t.Run(name, func(t *testing.T) {
+				err = VerifyAttestationStatement(attestationObject, clientDataJSONHash)
+				assert.NoError(t, err)
+			})
+		}
+	})
+
+	key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key2, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	t.Run("missing x5c", func(t *testing.T) {
+		attestationObject := createTestFIDOU2FAttestationObject(t,
+			[]byte{0, 0, 0, 0},
+			key1,
+			nil,
+		)
+		attestationObject.Statement["x5c"] = nil
+		err := VerifyAttestationStatement(attestationObject, ClientDataJSONHash{})
+		assert.Contains(t, err.Error(), "invalid x5c certificate")
+	})
+	t.Run("bad algorithm", func(t *testing.T) {
+		attestationObject := createTestFIDOU2FAttestationObject(t,
+			[]byte{0, 0, 0, 0},
+			key2,
+			nil,
+		)
+		err = VerifyAttestationStatement(attestationObject, ClientDataJSONHash{})
+		assert.Contains(t, err.Error(), "only the P-256 curve is supported")
+	})
+	t.Run("bad public key", func(t *testing.T) {
+		key, err := cose.NewRSAPublicKey(cose.AlgorithmRS256, rsaKey.PublicKey)
+		require.NoError(t, err)
+
+		rawKey, err := key.Marshal()
+		require.NoError(t, err)
+
+		attestationObject := createTestFIDOU2FAttestationObject(t,
+			[]byte{0, 0, 0, 0},
+			key1,
+			func(data *AuthenticatorData) {
+				data.AttestedCredentialData.CredentialPublicKey = rawKey
+			},
+		)
+		err = VerifyAttestationStatement(attestationObject, ClientDataJSONHash{})
+		assert.Contains(t, err.Error(), "only ECDSA keys are supported")
+	})
+	t.Run("bad signature", func(t *testing.T) {
+		attestationObject := createTestFIDOU2FAttestationObject(t,
+			[]byte{0, 0, 0, 0},
+			key1,
+			nil,
+		)
+		attestationObject.Statement["sig"] = nil
+		err := VerifyAttestationStatement(attestationObject, ClientDataJSONHash{})
+		assert.Contains(t, err.Error(), "invalid signature")
+	})
+}
+
+func createTestFIDOU2FAttestationObject(
+	t *testing.T,
+	rpID []byte,
+	privateKey *ecdsa.PrivateKey,
+	modifyAuthenticatorData func(data *AuthenticatorData),
+) *AttestationObject {
+	x5ctpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		SubjectKeyId:       generateSubjectKeyID(t, privateKey.Public()),
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		KeyUsage:           x509.KeyUsageDigitalSignature,
+	}
+	x5c, err := x509.CreateCertificate(rand.Reader, x5ctpl, x5ctpl, privateKey.Public(), privateKey)
+	require.NoError(t, err)
+
+	key, err := cose.NewECDSAPublicKey(cose.AlgorithmES256, privateKey.PublicKey)
+	require.NoError(t, err)
+	publicKeyU2F := key.RawX962ECC()
+
+	rawKey, err := key.Marshal()
+	require.NoError(t, err)
+
+	rpIDHash := sha256.Sum256(rpID)
+	authenticatorData := &AuthenticatorData{
+		RPIDHash:  rpIDHash,
+		Flags:     authenticatorFlagsAT,
+		SignCount: 0,
+		AttestedCredentialData: &AttestedCredentialData{
+			AAGUID:              newRandomAAGUID(),
+			CredentialID:        []byte{},
+			CredentialPublicKey: rawKey,
+		},
+		Extensions: []byte{},
+	}
+	if modifyAuthenticatorData != nil {
+		modifyAuthenticatorData(authenticatorData)
+	}
+	rawAuthenticatorData, err := authenticatorData.Marshal()
+	require.NoError(t, err)
+
+	verificationData := concat([]byte{0x00},
+		rpIDHash[:],
+		make([]byte, 32),
+		authenticatorData.AttestedCredentialData.CredentialID,
+		publicKeyU2F[:],
+	)
+	hashData := sha256.Sum256(verificationData)
+
+	rawSignature, err := ecdsa.SignASN1(rand.Reader, privateKey, hashData[:])
+	require.NoError(t, err)
+
+	return &AttestationObject{
+		AuthData: rawAuthenticatorData,
+		Format:   AttestationFormatFIDOU2F,
+		Statement: AttestationStatement{
+			"sig": rawSignature,
+			"x5c": []interface{}{
+				x5c,
+			},
+		},
+	}
+}

--- a/cose/key_ecdsa.go
+++ b/cose/key_ecdsa.go
@@ -26,6 +26,19 @@ func getECDSAVerifyFunc(hash crypto.Hash) ecdsaVerifyFunc {
 	}
 }
 
+// RawX962ECC represents the Raw ANSI X9.62 public key format for ALG_KEY_ECC_X962_RAW as defined in:
+// https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#public-key-representation-formats
+type RawX962ECC [65]byte
+
+// NewRawX962ECC creates a new RawX962ECC.
+func NewRawX962ECC(x, y [32]byte) RawX962ECC {
+	var arr RawX962ECC
+	arr[0] = 0x04
+	copy(arr[1:], x[:])
+	copy(arr[1+32:], y[:])
+	return arr
+}
+
 // An ECDSAPublicKey is a public key using ECDSA.
 type ECDSAPublicKey struct {
 	algorithm Algorithm
@@ -106,6 +119,14 @@ func (key ECDSAPublicKey) Algorithm() Algorithm {
 // CryptoPublicKey returns the crypto ECDSA public key.
 func (key ECDSAPublicKey) CryptoPublicKey() crypto.PublicKey {
 	return &key.key
+}
+
+// RawX962ECC returns the RawX962ECC formatted public key.
+func (key ECDSAPublicKey) RawX962ECC() RawX962ECC {
+	var x, y [32]byte
+	copy(x[:], key.key.X.Bytes())
+	copy(y[:], key.key.Y.Bytes())
+	return NewRawX962ECC(x, y)
 }
 
 // Type returns EC2.


### PR DESCRIPTION
Add `fido-u2f` attestation statement verification according to the spec: https://www.w3.org/TR/webauthn-2/#sctn-fido-u2f-attestation

This format only supports ECDSA P-256 keys.

Fixes https://github.com/pomerium/internal/issues/589