### PR TITLE
go: upgrade to go 1.18

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependency"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.x"
+          go-version: "1.18.x"
 
       - id: go-cache-paths
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/webauthn
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fxamacker/cbor/v2 v2.3.0


### PR DESCRIPTION
## Summary
Upgrade to go 1.18.

- https://github.com/pomerium/internal/issues/932