### PR TITLE
misc: better origin verification

### DIFF
--- a/misc_test.go
+++ b/misc_test.go
@@ -1,0 +1,29 @@
+package webauthn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_originMatches(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name               string
+		clientOrigin       string
+		relyingPartyOrigin string
+		matches            bool
+	}{
+		{"ignore schemas", "http://www.example.com", "https://www.example.com", true},
+		{"ignore ports", "http://www.example.com:8080", "https://www.example.com", true},
+		{"exact", "https://www.example.com", "https://www.example.com", true},
+		{"subdomain", "https://a.b.c.d.e.f.example.com", "https://example.com", true},
+		{"superdomain", "https://example.com", "https://www.example.com", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.matches, originMatches(tc.clientOrigin, tc.relyingPartyOrigin))
+		})
+	}
+}

--- a/relying_party.go
+++ b/relying_party.go
@@ -148,7 +148,7 @@ func (rp *RelyingParty) VerifyAuthenticationCeremony(
 	}
 
 	// 13. Verify that the value of C.origin matches the Relying Party's origin.
-	if !stringsAreEqual(clientData.Origin, rp.origin) {
+	if !originMatches(clientData.Origin, rp.origin) {
 		return nil, fmt.Errorf("invalid client data origin")
 	}
 
@@ -252,7 +252,7 @@ func (rp *RelyingParty) VerifyRegistrationCeremony(
 	}
 
 	//  9. Verify that the value of C.origin matches the Relying Party's origin.
-	if !stringsAreEqual(rp.origin, clientData.Origin) {
+	if !originMatches(clientData.Origin, rp.origin) {
 		return nil, fmt.Errorf("invalid client data origin")
 	}
 


### PR DESCRIPTION
## Summary
Currently we verify origins by using an exact match. However matching `www.example.com` to `example.com` should also be supported.

## Related issues
- https://github.com/pomerium/internal/issues/1013


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
