### PR TITLE
webauthn/ci: update lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.21.x
+          go-version: 1.23.x
           cache: false
 
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.55
+          version: v1.60.1
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  deadline: 20m
-
 linters-settings:
   dupl:
     threshold: 100
@@ -8,7 +5,11 @@ linters-settings:
     lines: 100
     statements: 50
   gci:
-    local-prefixes: github.com/pomerium/webauthn
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/pomerium)
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -29,16 +30,11 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/pomerium/webauthn
-  govet:
-    check-shadowing: false
   lll:
     line-length: 160
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -162,8 +158,3 @@ issues:
     - linters:
         - lll
       source: "^//go:generate "
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.34.x # use the fixed version to not introduce new linters unexpectedly

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.4
+golang 1.23.0


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1835

Update golangci-lint to v1.60.1