### PR TITLE
build(deps): bump github.com/ccoveille/go-safecast/v2

### DIFF
--- a/attested_credential_data.go
+++ b/attested_credential_data.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 
 	"github.com/pomerium/webauthn/fido"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pomerium/webauthn
 go 1.24.0
 
 require (
-	github.com/ccoveille/go-safecast v1.8.2
+	github.com/ccoveille/go-safecast/v2 v2.0.1
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/go-jose/go-jose/v3 v3.0.5
 	github.com/google/go-tpm v0.9.8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ccoveille/go-safecast v1.8.2 h1:+d+s5UGQiCVJX9oYc8XvYcB2zCMBlax6lIP7YdxXLHA=
-github.com/ccoveille/go-safecast v1.8.2/go.mod h1:M0Ubpl11x63fE7iOfk5MtngQFXsntcRzOoSsFDqQYDY=
+github.com/ccoveille/go-safecast/v2 v2.0.1 h1:2+mIu3gXtwmWelBia2kkxfB8eP4orTHDH7ClSlWkd6I=
+github.com/ccoveille/go-safecast/v2 v2.0.1/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

Migrate to v2 of go-safecast.

Note: I'm [go-safecast](https://github.com/ccoVeille/go-safecast) creator and maintainer.

The v2 has breaking changes for something you were not using.

You can read https://github.com/ccoVeille/go-safecast/releases/tag/v2.0.0 if you are interested.

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
